### PR TITLE
Add centralized error-handling middleware and adapt auth handlers

### DIFF
--- a/handlers/auth_handler_login_test.go
+++ b/handlers/auth_handler_login_test.go
@@ -56,9 +56,7 @@ func TestLoginHandlerIssueTokensError(t *testing.T) {
 	body, _ := json.Marshal(user)
 
 	req := httptest.NewRequest(http.MethodPost, "/login", bytes.NewBuffer(body))
-	rec := httptest.NewRecorder()
-
-	handler.LoginHandler(rec, req)
+	rec := executeRequest(handler.LoginHandler, req)
 	assert.Equal(t, http.StatusInternalServerError, rec.Code)
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
@@ -75,9 +73,7 @@ func TestLogoutHandlerRevokesToken(t *testing.T) {
 
 	req := httptest.NewRequest(http.MethodPost, "/logout", nil)
 	req.AddCookie(&http.Cookie{Name: cfg.Auth.RefreshCookieName, Value: token})
-	rec := httptest.NewRecorder()
-
-	handler.LogoutHandler(rec, req)
+	rec := executeRequest(handler.LogoutHandler, req)
 	assert.Equal(t, http.StatusOK, rec.Code)
 	assert.True(t, store.revoked)
 }

--- a/handlers/auth_handler_refresh_test.go
+++ b/handlers/auth_handler_refresh_test.go
@@ -15,15 +15,13 @@ func TestRefreshHandlerErrors(t *testing.T) {
 	cfg := configForTests()
 	handler := NewAuthHandler(cfg, &configurableTokenStore{})
 
-	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodPost, "/refresh", nil)
-	handler.RefreshHandler(rec, req)
+	rec := executeRequest(handler.RefreshHandler, req)
 	assert.Equal(t, http.StatusUnauthorized, rec.Code)
 
-	rec = httptest.NewRecorder()
 	req = httptest.NewRequest(http.MethodPost, "/refresh", nil)
 	req.AddCookie(&http.Cookie{Name: cfg.Auth.RefreshCookieName, Value: "invalid"})
-	handler.RefreshHandler(rec, req)
+	rec = executeRequest(handler.RefreshHandler, req)
 	assert.Equal(t, http.StatusUnauthorized, rec.Code)
 
 	claims := utils.Claims{Username: "user", Role: "role"}
@@ -32,17 +30,15 @@ func TestRefreshHandlerErrors(t *testing.T) {
 	assert.NoError(t, err)
 
 	handler = NewAuthHandler(cfg, &configurableTokenStore{exists: false})
-	rec = httptest.NewRecorder()
 	req = httptest.NewRequest(http.MethodPost, "/refresh", nil)
 	req.AddCookie(&http.Cookie{Name: cfg.Auth.RefreshCookieName, Value: validToken})
-	handler.RefreshHandler(rec, req)
+	rec = executeRequest(handler.RefreshHandler, req)
 	assert.Equal(t, http.StatusUnauthorized, rec.Code)
 
 	handler = NewAuthHandler(cfg, &configurableTokenStore{exists: true, revokeErr: assert.AnError})
-	rec = httptest.NewRecorder()
 	req = httptest.NewRequest(http.MethodPost, "/refresh", nil)
 	req.AddCookie(&http.Cookie{Name: cfg.Auth.RefreshCookieName, Value: validToken})
-	handler.RefreshHandler(rec, req)
+	rec = executeRequest(handler.RefreshHandler, req)
 	assert.Equal(t, http.StatusInternalServerError, rec.Code)
 }
 
@@ -50,9 +46,8 @@ func TestLogoutHandlerInvalidToken(t *testing.T) {
 	cfg := configForTests()
 	handler := NewAuthHandler(cfg, &configurableTokenStore{})
 
-	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodPost, "/logout", nil)
 	req.AddCookie(&http.Cookie{Name: cfg.Auth.RefreshCookieName, Value: "invalid"})
-	handler.LogoutHandler(rec, req)
+	rec := executeRequest(handler.LogoutHandler, req)
 	assert.Equal(t, http.StatusOK, rec.Code)
 }

--- a/middleware/error.go
+++ b/middleware/error.go
@@ -1,0 +1,94 @@
+package middleware
+
+import (
+	"encoding/json"
+	"errors"
+	"log"
+	"net/http"
+)
+
+type AppHandler func(http.ResponseWriter, *http.Request) error
+
+type AppError struct {
+	Status  int
+	Message string
+	Err     error
+}
+
+func (e *AppError) Error() string {
+	if e.Err != nil {
+		return e.Err.Error()
+	}
+	return e.Message
+}
+
+func (e *AppError) Unwrap() error {
+	return e.Err
+}
+
+func NewAppError(status int, message string, err error) *AppError {
+	return &AppError{Status: status, Message: message, Err: err}
+}
+
+type errorResponse struct {
+	Error string `json:"error"`
+}
+
+type responseWriter struct {
+	http.ResponseWriter
+	status      int
+	wroteHeader bool
+}
+
+func (rw *responseWriter) WriteHeader(statusCode int) {
+	if !rw.wroteHeader {
+		rw.status = statusCode
+		rw.wroteHeader = true
+	}
+	rw.ResponseWriter.WriteHeader(statusCode)
+}
+
+func ErrorHandler(handler AppHandler) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		rw := &responseWriter{ResponseWriter: w, status: http.StatusOK}
+		defer func() {
+			if recovered := recover(); recovered != nil {
+				log.Printf("panic recovered: %v", recovered)
+				if !rw.wroteHeader {
+					writeErrorResponse(rw, http.StatusInternalServerError, "Internal server error")
+				}
+			}
+		}()
+
+		if err := handler(rw, r); err != nil {
+			handleError(rw, r, err)
+		}
+	}
+}
+
+func handleError(w *responseWriter, r *http.Request, err error) {
+	status := http.StatusInternalServerError
+	message := "Internal server error"
+
+	var appErr *AppError
+	if errors.As(err, &appErr) {
+		status = appErr.Status
+		message = appErr.Message
+	}
+
+	if status >= http.StatusInternalServerError {
+		log.Printf("request failed: method=%s path=%s status=%d err=%v", r.Method, r.URL.Path, status, err)
+	}
+
+	if w.wroteHeader {
+		return
+	}
+
+	writeErrorResponse(w, status, message)
+}
+
+func writeErrorResponse(w http.ResponseWriter, status int, message string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(errorResponse{Error: message})
+}

--- a/routes/auth-route.go
+++ b/routes/auth-route.go
@@ -13,11 +13,11 @@ import (
 func SetupRoutes(cfg config.Config, authHandler *handlers.AuthHandler) *mux.Router {
 	router := mux.NewRouter()
 
-	router.HandleFunc("/register", authHandler.RegisterHandler).Methods("POST")
-	router.HandleFunc("/login", authHandler.LoginHandler).Methods("POST")
-	router.HandleFunc("/refresh", authHandler.RefreshHandler).Methods("POST")
-	router.HandleFunc("/logout", authHandler.LogoutHandler).Methods("POST")
-	router.Handle("/authenticate", middleware.AuthMiddleware(cfg)(http.HandlerFunc(authHandler.AuthenticateHandler))).Methods("GET")
+	router.HandleFunc("/register", middleware.ErrorHandler(authHandler.RegisterHandler)).Methods("POST")
+	router.HandleFunc("/login", middleware.ErrorHandler(authHandler.LoginHandler)).Methods("POST")
+	router.HandleFunc("/refresh", middleware.ErrorHandler(authHandler.RefreshHandler)).Methods("POST")
+	router.HandleFunc("/logout", middleware.ErrorHandler(authHandler.LogoutHandler)).Methods("POST")
+	router.Handle("/authenticate", middleware.AuthMiddleware(cfg)(middleware.ErrorHandler(authHandler.AuthenticateHandler))).Methods("GET")
 	router.HandleFunc("/health", handlers.HealthHandler).Methods("GET")
 
 	return router


### PR DESCRIPTION
### Motivation
- Provide a single, robust place to recover from panics and convert internal errors into standardized JSON HTTP responses.
- Surface clear HTTP status codes and human-friendly messages for database, token, and application errors.
- Reduce repeated `http.Error` boilerplate in auth handlers by returning typed errors handled centrally.
- Make tests exercise the middleware path so behaviour is consistent between handlers and routing.

### Description
- Add `middleware.ErrorHandler` and `middleware.AppError` to capture, unwrap and render errors as JSON and to recover from panics.
- Change auth handler signatures to return `error` (e.g. `func (h *AuthHandler) LoginHandler(w http.ResponseWriter, r *http.Request) error`) and return `middleware.NewAppError(...)` for expected failures.
- Wrap auth routes with `middleware.ErrorHandler` in `routes.SetupRoutes` and update the authenticate route to use `middleware.AuthMiddleware(cfg)(middleware.ErrorHandler(...))`.
- Update unit tests to invoke handlers through the middleware (add `executeRequest` helpers) and adjust tests to assert on the middleware-produced HTTP responses.

### Testing
- Attempted to run `go test ./...` in the workspace, but the command was interrupted/hung in this environment and did not complete.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6958c72e08d0832e949326b3d7586266)