### PR TITLE
Revamp RBAC models, add profiles, and normalize users schema

### DIFF
--- a/db/schema.sql
+++ b/db/schema.sql
@@ -1,0 +1,88 @@
+-- Core RBAC schema with profiles.
+CREATE EXTENSION IF NOT EXISTS "pgcrypto";
+CREATE EXTENSION IF NOT EXISTS "citext";
+
+CREATE TABLE IF NOT EXISTS roles (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    name CITEXT NOT NULL UNIQUE,
+    description TEXT NOT NULL DEFAULT '',
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS permissions (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    resource TEXT NOT NULL,
+    action TEXT NOT NULL,
+    description TEXT NOT NULL DEFAULT '',
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    UNIQUE (resource, action)
+);
+
+CREATE TABLE IF NOT EXISTS groups (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    name CITEXT NOT NULL UNIQUE,
+    description TEXT NOT NULL DEFAULT '',
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS users (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    username CITEXT NOT NULL UNIQUE,
+    email CITEXT UNIQUE,
+    password_hash TEXT NOT NULL,
+    role_id UUID NOT NULL REFERENCES roles(id) ON DELETE RESTRICT,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    CHECK (char_length(username) > 0)
+);
+
+CREATE TABLE IF NOT EXISTS profiles (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id UUID NOT NULL UNIQUE REFERENCES users(id) ON DELETE CASCADE,
+    first_name TEXT,
+    last_name TEXT,
+    display_name TEXT,
+    avatar_url TEXT,
+    phone_number TEXT,
+    locale TEXT,
+    timezone TEXT,
+    bio TEXT,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS user_roles (
+    user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    role_id UUID NOT NULL REFERENCES roles(id) ON DELETE CASCADE,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    PRIMARY KEY (user_id, role_id)
+);
+
+CREATE TABLE IF NOT EXISTS role_permissions (
+    role_id UUID NOT NULL REFERENCES roles(id) ON DELETE CASCADE,
+    permission_id UUID NOT NULL REFERENCES permissions(id) ON DELETE CASCADE,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    PRIMARY KEY (role_id, permission_id)
+);
+
+CREATE TABLE IF NOT EXISTS user_groups (
+    user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    group_id UUID NOT NULL REFERENCES groups(id) ON DELETE CASCADE,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    PRIMARY KEY (user_id, group_id)
+);
+
+CREATE TABLE IF NOT EXISTS group_roles (
+    group_id UUID NOT NULL REFERENCES groups(id) ON DELETE CASCADE,
+    role_id UUID NOT NULL REFERENCES roles(id) ON DELETE CASCADE,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    PRIMARY KEY (group_id, role_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_users_role_id ON users(role_id);
+CREATE INDEX IF NOT EXISTS idx_user_groups_group_id ON user_groups(group_id);
+CREATE INDEX IF NOT EXISTS idx_role_permissions_permission_id ON role_permissions(permission_id);
+CREATE INDEX IF NOT EXISTS idx_group_roles_role_id ON group_roles(role_id);

--- a/handlers/auth_handler_login_test.go
+++ b/handlers/auth_handler_login_test.go
@@ -46,13 +46,13 @@ func TestLoginHandlerIssueTokensError(t *testing.T) {
 	hashedPassword, err := bcrypt.GenerateFromPassword([]byte("password"), bcrypt.DefaultCost)
 	assert.NoError(t, err)
 
-	mock.ExpectQuery(`SELECT password, role FROM users WHERE username = \$1`).
+	mock.ExpectQuery(`SELECT u.password_hash, r.name FROM users u JOIN roles r ON r.id = u.role_id WHERE u.username = \$1`).
 		WithArgs("testuser").
 		WillReturnRows(sqlmock.NewRows([]string{"password", "role"}).
 			AddRow(string(hashedPassword), "jobseeker"))
 
 	handler := NewAuthHandler(configForTests(), &trackingTokenStore{})
-	user := models.Users{Username: "testuser", Password: "password"}
+	user := models.User{Username: "testuser", Password: "password"}
 	body, _ := json.Marshal(user)
 
 	req := httptest.NewRequest(http.MethodPost, "/login", bytes.NewBuffer(body))

--- a/models/group-role.go
+++ b/models/group-role.go
@@ -1,0 +1,9 @@
+package models
+
+import "time"
+
+type GroupRole struct {
+	GroupID   string    `json:"groupId"`
+	RoleID    string    `json:"roleId"`
+	CreatedAt time.Time `json:"createdAt"`
+}

--- a/models/group-roles.go
+++ b/models/group-roles.go
@@ -1,6 +1,0 @@
-package models
-
-type GroupRoles struct {
-	GroupID int `json:"groupId"`
-	RoleID  int `json:"roleId"`
-}

--- a/models/group.go
+++ b/models/group.go
@@ -1,0 +1,11 @@
+package models
+
+import "time"
+
+type Group struct {
+	ID          string    `json:"id"`
+	Name        string    `json:"name"`
+	Description string    `json:"description"`
+	CreatedAt   time.Time `json:"createdAt"`
+	UpdatedAt   time.Time `json:"updatedAt"`
+}

--- a/models/groups.go
+++ b/models/groups.go
@@ -1,7 +1,0 @@
-package models
-
-type Groups struct {
-	ID          int    `json:"id"`
-	Name        string `json:"name"`
-	Description string `json:"description"`
-}

--- a/models/permission.go
+++ b/models/permission.go
@@ -1,0 +1,12 @@
+package models
+
+import "time"
+
+type Permission struct {
+	ID          string    `json:"id"`
+	Resource    string    `json:"resource"`
+	Action      string    `json:"action"`
+	Description string    `json:"description"`
+	CreatedAt   time.Time `json:"createdAt"`
+	UpdatedAt   time.Time `json:"updatedAt"`
+}

--- a/models/permissions.go
+++ b/models/permissions.go
@@ -1,8 +1,0 @@
-package models
-
-type Permissions struct {
-	ID          int    `json:"id"`
-	Resource    string `json:"resource"`
-	Action      string `json:"action"`
-	Description string `json:"description"`
-}

--- a/models/profile.go
+++ b/models/profile.go
@@ -1,0 +1,18 @@
+package models
+
+import "time"
+
+type Profile struct {
+	ID          string    `json:"id"`
+	UserID      string    `json:"userId"`
+	FirstName   string    `json:"firstName,omitempty"`
+	LastName    string    `json:"lastName,omitempty"`
+	DisplayName string    `json:"displayName,omitempty"`
+	AvatarURL   string    `json:"avatarUrl,omitempty"`
+	PhoneNumber string    `json:"phoneNumber,omitempty"`
+	Locale      string    `json:"locale,omitempty"`
+	Timezone    string    `json:"timezone,omitempty"`
+	Bio         string    `json:"bio,omitempty"`
+	CreatedAt   time.Time `json:"createdAt"`
+	UpdatedAt   time.Time `json:"updatedAt"`
+}

--- a/models/role-permission.go
+++ b/models/role-permission.go
@@ -1,0 +1,9 @@
+package models
+
+import "time"
+
+type RolePermission struct {
+	RoleID       string    `json:"roleId"`
+	PermissionID string    `json:"permissionId"`
+	CreatedAt    time.Time `json:"createdAt"`
+}

--- a/models/role-permissions.go
+++ b/models/role-permissions.go
@@ -1,6 +1,0 @@
-package models
-
-type RolePermissions struct {
-	RoleID       int `json:"roleId"`
-	PermissionID int `json:"permissionId"`
-}

--- a/models/role.go
+++ b/models/role.go
@@ -1,0 +1,11 @@
+package models
+
+import "time"
+
+type Role struct {
+	ID          string    `json:"id"`
+	Name        string    `json:"name"`
+	Description string    `json:"description"`
+	CreatedAt   time.Time `json:"createdAt"`
+	UpdatedAt   time.Time `json:"updatedAt"`
+}

--- a/models/roles.go
+++ b/models/roles.go
@@ -1,7 +1,0 @@
-package models
-
-type Roles struct {
-	ID           int    `json:"id"`
-	Name         string `json:"name"`
-	Descriptions string `json:"description"`
-}

--- a/models/user-group.go
+++ b/models/user-group.go
@@ -1,0 +1,9 @@
+package models
+
+import "time"
+
+type UserGroup struct {
+	UserID    string    `json:"userId"`
+	GroupID   string    `json:"groupId"`
+	CreatedAt time.Time `json:"createdAt"`
+}

--- a/models/user-groups.go
+++ b/models/user-groups.go
@@ -1,6 +1,0 @@
-package models
-
-type UserGroups struct {
-	UserID  int `json:"userId"`
-	GroupID int `json:"groupId"`
-}

--- a/models/user-role.go
+++ b/models/user-role.go
@@ -1,0 +1,9 @@
+package models
+
+import "time"
+
+type UserRole struct {
+	UserID    string    `json:"userId"`
+	RoleID    string    `json:"roleId"`
+	CreatedAt time.Time `json:"createdAt"`
+}

--- a/models/user-roles.go
+++ b/models/user-roles.go
@@ -1,6 +1,0 @@
-package models
-
-type UserRoles struct {
-	UserID int `json:"userId"`
-	RoleID int `json:"roleId"`
-}

--- a/models/user.go
+++ b/models/user.go
@@ -1,0 +1,13 @@
+package models
+
+import "time"
+
+type User struct {
+	ID        string    `json:"id"`
+	Username  string    `json:"username"`
+	Email     string    `json:"email,omitempty"`
+	Password  string    `json:"password,omitempty"`
+	Role      string    `json:"role,omitempty"`
+	CreatedAt time.Time `json:"createdAt"`
+	UpdatedAt time.Time `json:"updatedAt"`
+}

--- a/models/users.go
+++ b/models/users.go
@@ -1,9 +1,0 @@
-// models/user.g
-package models
-
-type Users struct {
-	ID       int    `json:"id"`
-	Username string `json:"username"`
-	Password string `json:"password"`
-	Role     string `json:"role"`
-}


### PR DESCRIPTION
### Motivation
- Replace simplistic integer-based legacy structs with production-ready models using UUIDs and timestamps to support robust RBAC and profiles.
- Normalize user storage and role management by introducing `role_id` foreign keys and dedicated `roles` lookup to enforce constraints and separations of concern.
- Provide a canonical Postgres schema that includes constraints, indexes, and join tables for `roles`, `permissions`, `groups`, `user_roles`, `role_permissions`, `user_groups`, and `group_roles`.
- Update auth flows to align with the normalized schema and to enforce role validation during registration and login.

### Description
- Replaced legacy plural model structs with singular timestamped types: `User`, `Role`, `Permission`, `Group`, `Profile`, `UserRole`, `RolePermission`, `UserGroup`, and `GroupRole` in `models/`.
- Updated `handlers/auth-handler.go` to use `models.User`, hash `password` into `password_hash`, perform a role lookup (`SELECT id FROM roles WHERE name = $1`) inside a transaction, and insert users with `role_id` and nullable `email` as `sql.NullString`.
- Added `db/schema.sql` containing a complete Postgres schema using `UUID` primary keys, `citext` for case-insensitive unique names, referential integrity (`REFERENCES ... ON DELETE`), uniqueness constraints, and helpful indexes.
- Updated unit tests to match the new queries and models, adding `sqlmock` expectations for role lookups and `password_hash`/`role_id` usage.

### Testing
- Ran `gofmt -w` on modified files to ensure formatting consistency and applied changes to tests to reflect the new models and queries.
- Attempted to run unit tests with `go test ./...`, but the test run was interrupted before completion and produced no final pass/fail summary.
- `sqlmock` expectations were added/updated in tests to validate role lookups and user inserts under the new schema (tests updated in `handlers/*_test.go`).
- Manual `git` operations committed the changes as "Revamp RBAC models and schema" and added `db/schema.sql` for deployment/migrations.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695a9a8fadd0832e9a599a0c3b580d87)