### PR TITLE
Update routes to API v1 schema

### DIFF
--- a/routes/auth-route.go
+++ b/routes/auth-route.go
@@ -11,12 +11,15 @@ import (
 func SetupRoutes(cfg config.Config, authHandler *handlers.AuthHandler) *mux.Router {
 	router := mux.NewRouter()
 
-	router.HandleFunc("/register", middleware.ErrorHandler(authHandler.RegisterHandler)).Methods("POST")
-	router.HandleFunc("/login", middleware.ErrorHandler(authHandler.LoginHandler)).Methods("POST")
-	router.HandleFunc("/refresh", middleware.ErrorHandler(authHandler.RefreshHandler)).Methods("POST")
-	router.HandleFunc("/logout", middleware.ErrorHandler(authHandler.LogoutHandler)).Methods("POST")
-	router.Handle("/authenticate", middleware.AuthMiddleware(cfg)(middleware.ErrorHandler(authHandler.AuthenticateHandler))).Methods("GET")
-	router.HandleFunc("/health", handlers.HealthHandler).Methods("GET")
+	apiRouter := router.PathPrefix("/api/v1").Subrouter()
+	authRouter := apiRouter.PathPrefix("/auth").Subrouter()
+
+	authRouter.HandleFunc("/register", middleware.ErrorHandler(authHandler.RegisterHandler)).Methods("POST")
+	authRouter.HandleFunc("/login", middleware.ErrorHandler(authHandler.LoginHandler)).Methods("POST")
+	authRouter.HandleFunc("/refresh", middleware.ErrorHandler(authHandler.RefreshHandler)).Methods("POST")
+	authRouter.HandleFunc("/logout", middleware.ErrorHandler(authHandler.LogoutHandler)).Methods("POST")
+	authRouter.Handle("/authenticate", middleware.AuthMiddleware(cfg)(middleware.ErrorHandler(authHandler.AuthenticateHandler))).Methods("GET")
+	apiRouter.HandleFunc("/health", handlers.HealthHandler).Methods("GET")
 
 	return router
 }

--- a/routes/route_test.go
+++ b/routes/route_test.go
@@ -28,12 +28,12 @@ func TestSetupRoutes(t *testing.T) {
 		method string
 		path   string
 	}{
-		{"POST", "/register"},
-		{"POST", "/login"},
-		{"POST", "/logout"},
-		{"POST", "/refresh"},
-		{"GET", "/authenticate"},
-		{"GET", "/health"},
+		{"POST", "/api/v1/auth/register"},
+		{"POST", "/api/v1/auth/login"},
+		{"POST", "/api/v1/auth/logout"},
+		{"POST", "/api/v1/auth/refresh"},
+		{"GET", "/api/v1/auth/authenticate"},
+		{"GET", "/api/v1/health"},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
### Motivation
- The project has a new API schema which requires auth endpoints to be served under a versioned prefix so existing routes stopped working.
- The health endpoint should also be exposed under the same API versioning convention for consistency.

### Description
- Updated `routes/auth-route.go` to mount a versioned router with `apiRouter := router.PathPrefix("/api/v1").Subrouter()` and an auth subrouter `authRouter := apiRouter.PathPrefix("/auth").Subrouter()` and moved auth handlers under `/api/v1/auth`.
- Moved the health endpoint to `GET /api/v1/health` in `routes/auth-route.go`.
- Updated `routes/route_test.go` to assert the new paths such as `/api/v1/auth/register` and `/api/v1/health`.

### Testing
- The route unit test file `routes/route_test.go` was updated to match the new paths.
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695a9ce58894832e86b829ca04272049)