### PR TITLE
Return access tokens for bearer auth flows

### DIFF
--- a/handlers/auth_handler_internal_test.go
+++ b/handlers/auth_handler_internal_test.go
@@ -188,12 +188,12 @@ func TestLoginHandlerCompareError(t *testing.T) {
 
 func TestIssueTokensErrors(t *testing.T) {
 	handler := NewAuthHandler(configForTests(), nil)
-	err := handler.issueTokens(context.Background(), httptest.NewRecorder(), "user", "role")
+	_, err := handler.issueTokens(context.Background(), httptest.NewRecorder(), "user", "role")
 	assert.Error(t, err)
 
 	store := &configurableTokenStore{saveErr: errors.New("save error")}
 	handler = NewAuthHandler(configForTests(), store)
-	err = handler.issueTokens(context.Background(), httptest.NewRecorder(), "user", "role")
+	_, err = handler.issueTokens(context.Background(), httptest.NewRecorder(), "user", "role")
 	assert.Error(t, err)
 
 	originalRand := randRead
@@ -202,7 +202,7 @@ func TestIssueTokensErrors(t *testing.T) {
 	}
 
 	handler = NewAuthHandler(configForTests(), &configurableTokenStore{})
-	err = handler.issueTokens(context.Background(), httptest.NewRecorder(), "user", "role")
+	_, err = handler.issueTokens(context.Background(), httptest.NewRecorder(), "user", "role")
 	assert.Error(t, err)
 	randRead = originalRand
 
@@ -213,7 +213,7 @@ func TestIssueTokensErrors(t *testing.T) {
 	defer func() { generateToken = originalGenerateToken }()
 
 	handler = NewAuthHandler(configForTests(), &configurableTokenStore{})
-	err = handler.issueTokens(context.Background(), httptest.NewRecorder(), "user", "role")
+	_, err = handler.issueTokens(context.Background(), httptest.NewRecorder(), "user", "role")
 	assert.Error(t, err)
 
 	call := 0
@@ -225,7 +225,7 @@ func TestIssueTokensErrors(t *testing.T) {
 		return "token", nil
 	}
 	handler = NewAuthHandler(configForTests(), &configurableTokenStore{})
-	err = handler.issueTokens(context.Background(), httptest.NewRecorder(), "user", "role")
+	_, err = handler.issueTokens(context.Background(), httptest.NewRecorder(), "user", "role")
 	assert.Error(t, err)
 }
 
@@ -250,13 +250,13 @@ func TestRotateTokens(t *testing.T) {
 	handler := NewAuthHandler(configForTests(), &configurableTokenStore{revokeErr: errors.New("revoke error")})
 	claims := &utils.Claims{}
 	claims.ID = "id"
-	err := handler.rotateTokens(context.Background(), httptest.NewRecorder(), claims)
+	_, err := handler.rotateTokens(context.Background(), httptest.NewRecorder(), claims)
 	assert.Error(t, err)
 
 	handler = NewAuthHandler(configForTests(), &configurableTokenStore{exists: true})
 	claims = &utils.Claims{Username: "user", Role: "role"}
 	claims.ID = "id"
-	err = handler.rotateTokens(context.Background(), httptest.NewRecorder(), claims)
+	_, err = handler.rotateTokens(context.Background(), httptest.NewRecorder(), claims)
 	assert.NoError(t, err)
 }
 

--- a/handlers/auth_test.go
+++ b/handlers/auth_test.go
@@ -127,6 +127,10 @@ func TestLoginHandler(t *testing.T) {
 	assert.Equal(t, http.StatusOK, rec.Code)
 	cookies := rec.Result().Cookies()
 	assert.NotEmpty(t, cookies)
+
+	var payload map[string]interface{}
+	assert.NoError(t, json.NewDecoder(rec.Body).Decode(&payload))
+	assert.NotEmpty(t, payload["access_token"])
 }
 
 func TestLoginHandler_WrongPassword(t *testing.T) {
@@ -180,6 +184,10 @@ func TestRefreshHandler(t *testing.T) {
 		refreshReq.AddCookie(refreshCookie)
 		refreshRec := executeRequest(handler.RefreshHandler, refreshReq)
 		assert.Equal(t, http.StatusOK, refreshRec.Code)
+
+		var payload map[string]interface{}
+		assert.NoError(t, json.NewDecoder(refreshRec.Body).Decode(&payload))
+		assert.NotEmpty(t, payload["access_token"])
 	}
 }
 


### PR DESCRIPTION
### Motivation

- Surface the access token and metadata in login and refresh responses so clients can use bearer auth across services in addition to cookie-based flows.
- Support token rotation flows that return the newly issued access token to the caller for immediate use.
- Make token issuance functions return the generated access token to simplify response construction and testing.

### Description

- `LoginHandler` and `RefreshHandler` now include `access_token`, `token_type`, and `expires_in` in their JSON responses.
- `issueTokens` and `rotateTokens` signatures were changed to return the newly issued access token (string) along with errors. 
- Tests updated to assert the presence of `access_token` in `handlers/auth_test.go` and internal tests adjusted for the new return values in `handlers/auth_handler_internal_test.go`.
- Minor error-handling return value adjustments to propagate the access token or errors appropriately.

### Testing

- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695aa2a89858832eb5e02c5df1dd5d64)