### PR TITLE
Remove Authenticate handler and tests

### DIFF
--- a/handlers/auth-handler.go
+++ b/handlers/auth-handler.go
@@ -173,21 +173,6 @@ func (h *AuthHandler) RefreshHandler(w http.ResponseWriter, r *http.Request) err
 	return nil
 }
 
-func (h *AuthHandler) AuthenticateHandler(w http.ResponseWriter, r *http.Request) error {
-	claims, ok := middleware.ClaimsFromContext(r.Context())
-	if !ok {
-		return middleware.NewAppError(http.StatusUnauthorized, "Unauthorized", nil)
-	}
-
-	json.NewEncoder(w).Encode(map[string]interface{}{
-		"valid":    true,
-		"message":  "Token is valid",
-		"username": claims.Username,
-		"role":     claims.Role,
-	})
-	return nil
-}
-
 func (h *AuthHandler) LogoutHandler(w http.ResponseWriter, r *http.Request) error {
 	w.Header().Set("Content-Type", "application/json")
 

--- a/handlers/auth_test.go
+++ b/handlers/auth_test.go
@@ -12,9 +12,7 @@ import (
 	"auth-service/config"
 	"auth-service/db"
 	"auth-service/handlers"
-	"auth-service/middleware"
 	"auth-service/models"
-	"auth-service/utils"
 
 	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/stretchr/testify/assert"
@@ -189,18 +187,6 @@ func TestRefreshHandler(t *testing.T) {
 		assert.NoError(t, json.NewDecoder(refreshRec.Body).Decode(&payload))
 		assert.NotEmpty(t, payload["access_token"])
 	}
-}
-
-func TestAuthenticateHandler(t *testing.T) {
-	handler := handlers.NewAuthHandler(testConfig(), newStubTokenStore())
-	req := httptest.NewRequest("GET", "/authenticate", nil)
-	rec := executeRequest(handler.AuthenticateHandler, req)
-	assert.Equal(t, http.StatusUnauthorized, rec.Code)
-
-	claims := &utils.Claims{Username: "testuser", Role: "admin"}
-	req = req.WithContext(middleware.ContextWithClaims(req.Context(), claims))
-	rec = executeRequest(handler.AuthenticateHandler, req)
-	assert.Equal(t, http.StatusOK, rec.Code)
 }
 
 func TestLogoutHandler(t *testing.T) {

--- a/routes/auth-route.go
+++ b/routes/auth-route.go
@@ -18,7 +18,6 @@ func SetupRoutes(cfg config.Config, authHandler *handlers.AuthHandler) *mux.Rout
 	authRouter.HandleFunc("/login", middleware.ErrorHandler(authHandler.LoginHandler)).Methods("POST")
 	authRouter.HandleFunc("/refresh", middleware.ErrorHandler(authHandler.RefreshHandler)).Methods("POST")
 	authRouter.HandleFunc("/logout", middleware.ErrorHandler(authHandler.LogoutHandler)).Methods("POST")
-	authRouter.Handle("/authenticate", middleware.AuthMiddleware(cfg)(middleware.ErrorHandler(authHandler.AuthenticateHandler))).Methods("GET")
 	apiRouter.HandleFunc("/health", handlers.HealthHandler).Methods("GET")
 
 	return router

--- a/routes/route_test.go
+++ b/routes/route_test.go
@@ -32,7 +32,6 @@ func TestSetupRoutes(t *testing.T) {
 		{"POST", "/api/v1/auth/login"},
 		{"POST", "/api/v1/auth/logout"},
 		{"POST", "/api/v1/auth/refresh"},
-		{"GET", "/api/v1/auth/authenticate"},
 		{"GET", "/api/v1/health"},
 	}
 


### PR DESCRIPTION
### Motivation
- Simplify the authentication microservice API by removing an explicit `authenticate` endpoint that only duplicated middleware-based token validation.
- Keep the exposed routes minimal and focused on core auth operations: `register`, `login`, `refresh`, `logout`, and `health`.
- Remove redundant handler and its test to avoid surface area and maintenance for an endpoint not required by the service.

### Description
- Deleted the `AuthenticateHandler` implementation from `handlers/auth-handler.go`.
- Removed the `TestAuthenticateHandler` test case from `handlers/auth_test.go` and cleaned up now-unused imports.
- Ensured route registration no longer expects `GET /api/v1/auth/authenticate` in `routes/route_test.go` (route was already removed in prior diffs).
- Committed formatting cleanup with `gofmt` on modified test files.

### Testing
- No automated tests were executed as part of this change.
- Existing unit test updates were made (the authenticate test was removed) but not run in CI during this change.
- Local formatting (`gofmt`) was applied successfully.
- No runtime or integration tests were performed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695aa99c4b00832eb6c38cffdddc8331)