### PR TITLE
Add JWKS-based RS256 access tokens and opaque refresh rotation

### DIFF
--- a/example.env
+++ b/example.env
@@ -12,8 +12,9 @@ DB_PASSWORD=postgres
 DB_SSLMODE=disable
 
 # JWT
-JWT_ACCESS_SECRET=change-me-access-secret
-JWT_REFRESH_SECRET=change-me-refresh-secret
+JWT_ACCESS_PRIVATE_KEY=-----BEGIN PRIVATE KEY-----\nchange-me\n-----END PRIVATE KEY-----
+JWT_ACCESS_PUBLIC_KEY=-----BEGIN PUBLIC KEY-----\nchange-me\n-----END PUBLIC KEY-----
+JWT_ACCESS_KID=auth-service-1
 JWT_ISSUER=auth-service
 JWT_ACCESS_TTL=15m
 JWT_REFRESH_TTL=720h

--- a/handlers/jwks-handler.go
+++ b/handlers/jwks-handler.go
@@ -1,0 +1,24 @@
+package handlers
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"auth-service/middleware"
+	"auth-service/utils"
+)
+
+func (h *AuthHandler) JWKSHandler(w http.ResponseWriter, r *http.Request) error {
+	w.Header().Set("Content-Type", "application/json")
+
+	jwks := utils.JWKS{
+		Keys: []utils.JWK{
+			utils.NewRSAJWK(h.cfg.Auth.AccessTokenPublicKey, h.cfg.Auth.AccessTokenKeyID),
+		},
+	}
+
+	if err := json.NewEncoder(w).Encode(jwks); err != nil {
+		return middleware.NewAppError(http.StatusInternalServerError, "Could not encode JWKS", err)
+	}
+	return nil
+}

--- a/middleware/auth.go
+++ b/middleware/auth.go
@@ -22,7 +22,7 @@ func AuthMiddleware(cfg config.Config) func(http.Handler) http.Handler {
 				return
 			}
 
-			claims, err := utils.ParseToken(token, cfg.Auth.AccessTokenSecret)
+			claims, err := utils.ParseAccessToken(token, cfg.Auth.AccessTokenPublicKey)
 			if err != nil {
 				http.Error(w, "Invalid or expired token", http.StatusUnauthorized)
 				return

--- a/routes/auth-route.go
+++ b/routes/auth-route.go
@@ -18,6 +18,7 @@ func SetupRoutes(cfg config.Config, authHandler *handlers.AuthHandler) *mux.Rout
 	authRouter.HandleFunc("/login", middleware.ErrorHandler(authHandler.LoginHandler)).Methods("POST")
 	authRouter.HandleFunc("/refresh", middleware.ErrorHandler(authHandler.RefreshHandler)).Methods("POST")
 	authRouter.HandleFunc("/logout", middleware.ErrorHandler(authHandler.LogoutHandler)).Methods("POST")
+	apiRouter.HandleFunc("/.well-known/jwks.json", middleware.ErrorHandler(authHandler.JWKSHandler)).Methods("GET")
 	apiRouter.HandleFunc("/health", handlers.HealthHandler).Methods("GET")
 
 	return router

--- a/routes/route_test.go
+++ b/routes/route_test.go
@@ -1,6 +1,8 @@
 package routes_test
 
 import (
+	"crypto/rand"
+	"crypto/rsa"
 	"net/http"
 	"testing"
 
@@ -13,10 +15,14 @@ import (
 )
 
 func TestSetupRoutes(t *testing.T) {
+	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	assert.NoError(t, err)
 	cfg := config.Config{
 		Auth: config.AuthConfig{
-			AccessTokenSecret: []byte("test"),
-			AccessCookieName:  "access_token",
+			AccessTokenPrivateKey: privateKey,
+			AccessTokenPublicKey:  &privateKey.PublicKey,
+			AccessTokenKeyID:      "kid",
+			AccessCookieName:      "access_token",
 		},
 	}
 
@@ -32,6 +38,7 @@ func TestSetupRoutes(t *testing.T) {
 		{"POST", "/api/v1/auth/login"},
 		{"POST", "/api/v1/auth/logout"},
 		{"POST", "/api/v1/auth/refresh"},
+		{"GET", "/api/v1/.well-known/jwks.json"},
 		{"GET", "/api/v1/health"},
 	}
 

--- a/utils/jwks.go
+++ b/utils/jwks.go
@@ -1,0 +1,36 @@
+package utils
+
+import (
+	"crypto/rsa"
+	"encoding/base64"
+	"math/big"
+)
+
+type JWKS struct {
+	Keys []JWK `json:"keys"`
+}
+
+type JWK struct {
+	Kty string `json:"kty"`
+	Use string `json:"use,omitempty"`
+	Kid string `json:"kid,omitempty"`
+	Alg string `json:"alg,omitempty"`
+	N   string `json:"n,omitempty"`
+	E   string `json:"e,omitempty"`
+}
+
+func NewRSAJWK(publicKey *rsa.PublicKey, keyID string) JWK {
+	if publicKey == nil {
+		return JWK{}
+	}
+
+	e := big.NewInt(int64(publicKey.E))
+	return JWK{
+		Kty: "RSA",
+		Use: "sig",
+		Kid: keyID,
+		Alg: "RS256",
+		N:   base64.RawURLEncoding.EncodeToString(publicKey.N.Bytes()),
+		E:   base64.RawURLEncoding.EncodeToString(e.Bytes()),
+	}
+}

--- a/utils/refresh_token.go
+++ b/utils/refresh_token.go
@@ -1,0 +1,23 @@
+package utils
+
+import (
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+)
+
+var randRead = rand.Read
+
+func GenerateRefreshToken() (string, error) {
+	buffer := make([]byte, 32)
+	if _, err := randRead(buffer); err != nil {
+		return "", err
+	}
+	return base64.RawURLEncoding.EncodeToString(buffer), nil
+}
+
+func HashRefreshToken(token string) string {
+	sum := sha256.Sum256([]byte(token))
+	return hex.EncodeToString(sum[:])
+}


### PR DESCRIPTION
### Motivation

- Move access token signing to asymmetric keys (RS256) and expose a JWKS endpoint so third parties can verify tokens without sharing secrets.
- Replace JWT refresh tokens with opaque, server-rotated refresh tokens to enable reuse detection and safer session handling.
- Store only hashed refresh tokens in Valkey and track sessions to allow revocation and replay protection.
- Update configuration to load RSA keys from PEM environment variables for production-friendly secret management.

### Description

- Switched access token code to `GenerateAccessToken`/`ParseAccessToken` (RS256) and added JWKS support with a new `JWKSHandler`, `utils/jwks.go`, and route `/.well-known/jwks.json`.
- Implemented opaque refresh tokens with `GenerateRefreshToken` and `HashRefreshToken` in `utils/refresh_token.go`, and updated auth flows to rotate tokens and store hashed tokens and session metadata via a richer `RefreshTokenStore` API in `store/valkey.go`.
- Updated configuration to parse RSA PEM keys from `JWT_ACCESS_PRIVATE_KEY` and optional `JWT_ACCESS_PUBLIC_KEY`, and added `JWT_ACCESS_KID` and example env changes in `example.env`.
- Updated middleware, handlers, and many tests to use the new APIs and store behavior, and added helpers for session revocation and reuse detection (`revokeSession`, `MarkRevoked`, `IsRevoked`, etc.).

### Testing

- Ran unit tests with `go test ./...` and the test suite passed (`ok auth-service`).
- Updated and verified unit tests across `utils`, `handlers`, `store`, `middleware`, and `config` to reflect the new token and store APIs.
- Formatted modified files with `gofmt` as part of the changeset to ensure code style consistency.
- No manual integration tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695aabc80754832e84a1737d430ac7b8)