### PR TITLE
Fix register handler sqlmock transaction expectations

### DIFF
--- a/handlers/auth_test.go
+++ b/handlers/auth_test.go
@@ -116,12 +116,14 @@ func TestRegisterHandler(t *testing.T) {
 	mock, cleanup := setupMockDB()
 	defer cleanup()
 
+	mock.ExpectBegin()
 	mock.ExpectQuery("SELECT id FROM roles WHERE name = \\$1").
 		WithArgs("jobseeker").
 		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow("role-id"))
 	mock.ExpectExec("INSERT INTO users").
 		WithArgs("testuser", sqlmock.AnyArg(), sqlmock.AnyArg(), "role-id").
 		WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectCommit()
 
 	handler := handlers.NewAuthHandler(testConfig(), newStubTokenStore())
 	user := models.User{Username: "testuser", Password: "password", Role: "jobseeker"}


### PR DESCRIPTION
### Motivation
- The register handler test lacked transaction expectations which caused mismatches with code that begins and commits a DB transaction.
- Adding explicit begin/commit expectations ensures `sqlmock` correctly validates the transactional queries.

### Description
- Added `mock.ExpectBegin()` before the role lookup in `TestRegisterHandler` in `handlers/auth_test.go`.
- Added `mock.ExpectCommit()` after the user `INSERT` expectation in `TestRegisterHandler`.

### Testing
- Ran `go test ./handlers` which was started but the run was interrupted/hung in this environment.
- No other automated test runs were performed in this rollout.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695ba2a478fc832ebdca24434aff984a)