### PR TITLE
Fix handler test imports and transaction expectations

### DIFF
--- a/handlers/auth_handler_internal_test.go
+++ b/handlers/auth_handler_internal_test.go
@@ -149,12 +149,14 @@ func TestRegisterHandlerDBError(t *testing.T) {
 	mock, cleanup := setupMockDB(t)
 	defer cleanup()
 
+	mock.ExpectBegin()
 	mock.ExpectQuery("SELECT id FROM roles WHERE name = \\$1").
 		WithArgs("user").
 		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow("role-id"))
 	mock.ExpectExec("INSERT INTO users").
 		WithArgs("user", sqlmock.AnyArg(), sqlmock.AnyArg(), "role-id").
 		WillReturnError(errors.New("db error"))
+	mock.ExpectRollback()
 
 	body, _ := json.Marshal(models.User{Username: "user", Password: "pass"})
 	req := httptest.NewRequest(http.MethodPost, "/register", bytes.NewBuffer(body))

--- a/handlers/auth_test.go
+++ b/handlers/auth_test.go
@@ -14,6 +14,7 @@ import (
 	"auth-service/config"
 	"auth-service/db"
 	"auth-service/handlers"
+	"auth-service/middleware"
 	"auth-service/models"
 	"auth-service/store"
 	"auth-service/utils"


### PR DESCRIPTION
### Motivation
- Handler tests were failing: one test file failed to compile due to a missing import and another sqlmock expectation did not match the handler's transaction behavior, causing `go test ./...` to fail.
- The change aims to make the unit tests align with the actual handler implementation so the full test suite runs reliably.

### Description
- Add the missing import `"auth-service/middleware"` to `handlers/auth_test.go` so the test helper and types compile. 
- Update `TestRegisterHandlerDBError` in `handlers/auth_handler_internal_test.go` to expect a transaction `Begin` and a `Rollback` by adding `mock.ExpectBegin()` and `mock.ExpectRollback()` to match the handler's use of a transaction. 
- Adjusted test expectations to reflect the handler's database control flow when an insert fails.

### Testing
- Ran the full unit test suite with `go test ./...` and all tests passed. 
- Verified handler package tests specifically succeeded after the fixes (`ok	auth-service/handlers`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6970f3424008832e85e2ae3f3af51cab)