### PR TITLE
Update Dockerfile to multi-stage build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,21 +1,31 @@
 # Dockerfile
-FROM golang:1.23.2-alpine
+FROM golang:1.23.2-alpine AS builder
 
 WORKDIR /app
 
 # Install necessary dependencies
 RUN apk add --no-cache git
 
+# Download Go modules
+COPY go.mod go.sum ./
+RUN go mod download
+
 # Copy project files
 COPY . .
 
-# Download Go modules
-RUN go mod tidy
-
 # Build the application
-RUN go build -o auth-service main.go
+RUN CGO_ENABLED=0 go build -o /auth-service main.go
+
+FROM alpine:3.20
+
+RUN apk add --no-cache ca-certificates
+RUN adduser -D -g '' appuser
+
+WORKDIR /app
+COPY --from=builder /auth-service /app/auth-service
 
 # Expose port 8080 for the API
 EXPOSE 8080
 
-CMD ["./auth-service"]
+USER appuser
+ENTRYPOINT ["./auth-service"]


### PR DESCRIPTION
### Motivation
- Reduce final image size and improve build caching by separating build and runtime stages.
- Cache Go module downloads to avoid re-downloading dependencies on every build by copying `go.mod`/`go.sum` first.
- Run the service as a non-root user with CA certificates installed for secure TLS connections.

### Description
- Replace single-stage image with a builder stage `FROM golang:1.23.2-alpine AS builder` and a slim runtime `FROM alpine:3.20`.
- Cache modules by adding `COPY go.mod go.sum ./` and `RUN go mod download`, then build with `CGO_ENABLED=0 go build -o /auth-service main.go` in the builder stage.
- Install `ca-certificates`, create a non-root `appuser`, copy the statically-built binary with `COPY --from=builder /auth-service /app/auth-service`, expose port `8080`, switch to `USER appuser`, and set `ENTRYPOINT ["./auth-service"]`.

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69744525678c832ea7bcacf16eeef302)