### PR TITLE
Support escaped newline JWT key env vars

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -85,8 +85,8 @@ func Load() (Config, error) {
 		dbName = os.Getenv("DB_INSTANCE_IDENTIFIER")
 	}
 
-	accessPrivateKeyPEM := os.Getenv("JWT_ACCESS_PRIVATE_KEY")
-	accessPublicKeyPEM := os.Getenv("JWT_ACCESS_PUBLIC_KEY")
+	accessPrivateKeyPEM := normalizePEMEnv(os.Getenv("JWT_ACCESS_PRIVATE_KEY"))
+	accessPublicKeyPEM := normalizePEMEnv(os.Getenv("JWT_ACCESS_PUBLIC_KEY"))
 	if accessPrivateKeyPEM == "" {
 		return Config{}, errors.New("JWT_ACCESS_PRIVATE_KEY must be set")
 	}
@@ -239,6 +239,13 @@ func parseRSAPublicKey(pemValue string) (*rsa.PublicKey, error) {
 		return nil, errors.New("JWT_ACCESS_PUBLIC_KEY is not RSA")
 	}
 	return publicKey, nil
+}
+
+func normalizePEMEnv(value string) string {
+	if value == "" {
+		return value
+	}
+	return strings.ReplaceAll(value, `\n`, "\n")
 }
 
 func getEnv(key, fallback string) string {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -6,6 +6,7 @@ import (
 	"crypto/x509"
 	"encoding/pem"
 	"net/http"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -100,4 +101,17 @@ func TestLoadMissingDatabaseConfig(t *testing.T) {
 	t.Setenv("DB_USERNAME", "")
 	_, err := Load()
 	assert.Error(t, err)
+}
+
+func TestLoadHandlesEscapedNewlinesInKeys(t *testing.T) {
+	privateKeyPEM, publicKeyPEM := testKeyPair(t)
+	t.Setenv("JWT_ACCESS_PRIVATE_KEY", strings.ReplaceAll(privateKeyPEM, "\n", `\n`))
+	t.Setenv("JWT_ACCESS_PUBLIC_KEY", strings.ReplaceAll(publicKeyPEM, "\n", `\n`))
+	t.Setenv("DB_NAME", "auth")
+	t.Setenv("DB_USERNAME", "user")
+
+	cfg, err := Load()
+	assert.NoError(t, err)
+	assert.NotNil(t, cfg.Auth.AccessTokenPrivateKey)
+	assert.NotNil(t, cfg.Auth.AccessTokenPublicKey)
 }


### PR DESCRIPTION
### Motivation
- Environment providers sometimes store PEM keys on a single line with escaped newlines (`\n`) which breaks `pem.Decode` when parsing JWT keys. 

### Description
- Add `normalizePEMEnv` which replaces literal `\n` sequences with real newlines and use it when reading `JWT_ACCESS_PRIVATE_KEY` and `JWT_ACCESS_PUBLIC_KEY` in `Load`. 
- Preserve existing parsing logic by passing the normalized PEM into `parseRSAPrivateKey`/`parseRSAPublicKey`. 
- Add `TestLoadHandlesEscapedNewlinesInKeys` in `config/config_test.go` to cover single-line escaped-newline key values and import `strings` for test manipulation. 

### Testing
- Ran `go test ./config` which passed (`ok auth-service/config`).
- Attempted `go test ./...` in this environment but the command did not produce a full completion result here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6974523f1b88832eaffcb018d010d356)