### PR TITLE
Normalize quoted and Windows-style PEM env values

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -242,10 +242,19 @@ func parseRSAPublicKey(pemValue string) (*rsa.PublicKey, error) {
 }
 
 func normalizePEMEnv(value string) string {
+	value = strings.TrimSpace(value)
 	if value == "" {
 		return value
 	}
-	return strings.ReplaceAll(value, `\n`, "\n")
+	if (strings.HasPrefix(value, "\"") && strings.HasSuffix(value, "\"")) ||
+		(strings.HasPrefix(value, "'") && strings.HasSuffix(value, "'")) {
+		value = value[1 : len(value)-1]
+	}
+	value = strings.ReplaceAll(value, `\r\n`, "\n")
+	value = strings.ReplaceAll(value, `\n`, "\n")
+	value = strings.ReplaceAll(value, "\r\n", "\n")
+	value = strings.ReplaceAll(value, "\r", "\n")
+	return value
 }
 
 func getEnv(key, fallback string) string {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -115,3 +115,16 @@ func TestLoadHandlesEscapedNewlinesInKeys(t *testing.T) {
 	assert.NotNil(t, cfg.Auth.AccessTokenPrivateKey)
 	assert.NotNil(t, cfg.Auth.AccessTokenPublicKey)
 }
+
+func TestLoadHandlesQuotedEscapedNewlinesInKeys(t *testing.T) {
+	privateKeyPEM, publicKeyPEM := testKeyPair(t)
+	t.Setenv("JWT_ACCESS_PRIVATE_KEY", `"`+strings.ReplaceAll(privateKeyPEM, "\n", `\n`)+`"`)
+	t.Setenv("JWT_ACCESS_PUBLIC_KEY", `'`+strings.ReplaceAll(publicKeyPEM, "\n", `\n`)+`'`)
+	t.Setenv("DB_NAME", "auth")
+	t.Setenv("DB_USERNAME", "user")
+
+	cfg, err := Load()
+	assert.NoError(t, err)
+	assert.NotNil(t, cfg.Auth.AccessTokenPrivateKey)
+	assert.NotNil(t, cfg.Auth.AccessTokenPublicKey)
+}


### PR DESCRIPTION
### Motivation
- Env files and container `--env-file` usage often supply PEMs with escaped newlines, surrounding quotes, or CRLF line endings which caused PEM parsing to fail when loading keys.

### Description
- Update `normalizePEMEnv` in `config/config.go` to `TrimSpace`, strip surrounding single or double quotes, and normalize escaped `\n`, escaped `\r\n`, and raw `\r\n`/`\r` into Unix `\n` line endings.
- Preserve the existing empty-value behavior so an empty env still returns an empty string.
- Add `TestLoadHandlesQuotedEscapedNewlinesInKeys` in `config/config_test.go` to cover quoted-and-escaped PEM environment values.
- Modified files: `config/config.go` and `config/config_test.go`.

### Testing
- Added a unit test `TestLoadHandlesQuotedEscapedNewlinesInKeys` and relied on the existing `TestLoadHandlesEscapedNewlinesInKeys` for coverage of escaped newlines.
- No automated test suite or CI jobs were executed as part of this change (tests were added but not run).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6974601dfe9c832ea7b06270e3352145)