### PR TITLE
Add local ADOT OpenTelemetry collector config and run guide

### DIFF
--- a/telemetry/ADOT-LOCAL.md
+++ b/telemetry/ADOT-LOCAL.md
@@ -1,0 +1,47 @@
+# ADOT local collector for OpenTelemetry testing
+
+This repository uses OTLP exporters configured by environment variables. The
+collector config below listens on the default OTLP gRPC port `4317` and OTLP HTTP
+port `4318` so you can verify traces/metrics locally without sending data to AWS.
+
+## 1) Save the collector config
+
+The repo includes a minimal config at `telemetry/adot-collector.yaml`.
+
+## 2) Run the ADOT collector in Docker
+
+```bash
+docker run --rm --name adot-collector \
+  -p 4317:4317 \
+  -p 4318:4318 \
+  -v "$PWD/telemetry/adot-collector.yaml:/etc/otel-collector-config.yaml:ro" \
+  public.ecr.aws/aws-observability/aws-otel-collector:latest \
+  --config /etc/otel-collector-config.yaml
+```
+
+## 3) Point the service at the local collector
+
+Use these environment variables (set in your `.env` or shell):
+
+```bash
+export OTEL_EXPORTER_OTLP_ENDPOINT=localhost:4317
+export OTEL_EXPORTER_OTLP_PROTOCOL=grpc
+export OTEL_EXPORTER_OTLP_INSECURE=true
+```
+
+Optionally override traces/metrics endpoints:
+
+```bash
+export OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=localhost:4317
+export OTEL_EXPORTER_OTLP_METRICS_ENDPOINT=localhost:4317
+```
+
+## 4) Generate traffic
+
+Start the service and hit any HTTP route. The ADOT collector logs should show
+received spans/metrics because the config uses the `logging` exporter.
+
+## 5) Switching to AWS backends (optional)
+
+Once you confirm local exports, swap the `logging` exporter in the collector
+config for AWS exporters (e.g., X-Ray, CloudWatch, AMP) and supply credentials.

--- a/telemetry/adot-collector.yaml
+++ b/telemetry/adot-collector.yaml
@@ -1,0 +1,25 @@
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:4317
+      http:
+        endpoint: 0.0.0.0:4318
+
+processors:
+  batch: {}
+
+exporters:
+  logging:
+    verbosity: detailed
+
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [logging]
+    metrics:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [logging]


### PR DESCRIPTION
### Motivation

- Provide a minimal ADOT OpenTelemetry Collector configuration so the service can export OTLP traces and metrics locally without sending data to AWS.

### Description

- Add `telemetry/adot-collector.yaml` containing OTLP `grpc` (`4317`) and `http` (`4318`) receivers, a `batch` processor, and a `logging` exporter wired for traces and metrics.
- Add `telemetry/ADOT-LOCAL.md` with instructions and the Docker command to run the collector: `docker run --rm --name adot-collector -p 4317:4317 -p 4318:4318 -v "$PWD/telemetry/adot-collector.yaml:/etc/otel-collector-config.yaml:ro" public.ecr.aws/aws-observability/aws-otel-collector:latest --config /etc/otel-collector-config.yaml`.
- Document example environment variables to point the service at the local collector such as `OTEL_EXPORTER_OTLP_ENDPOINT=localhost:4317`, `OTEL_EXPORTER_OTLP_PROTOCOL=grpc`, and `OTEL_EXPORTER_OTLP_INSECURE=true`.

### Testing

- No automated tests were run because the change is configuration and documentation only.
- Basic repository validation was performed by adding and committing the new files (`telemetry/adot-collector.yaml`, `telemetry/ADOT-LOCAL.md`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69746da9cac8832e9370fb59d5471a5a)