### PR TITLE
Add ECS ADOT sidecar collector documentation and ECS collector config

### DIFF
--- a/telemetry/ADOT-ECS-SIDECAR.md
+++ b/telemetry/ADOT-ECS-SIDECAR.md
@@ -1,0 +1,106 @@
+# ADOT sidecar on ECS (per-service collector)
+
+This service already exports OTLP traces and metrics. On ECS you can run the
+AWS Distro for OpenTelemetry (ADOT) Collector as a sidecar and point the app to
+`localhost:4317`. The sidecar then forwards to X-Ray, CloudWatch, and AMP.
+
+## 1) Collector configuration
+
+Use the provided config at `telemetry/adot-collector-ecs.yaml`. It receives OTLP
+over gRPC on `4317` and exports:
+
+- **Traces** → X-Ray (`awsxray` exporter)
+- **Metrics** → CloudWatch (`awsemf` exporter) and AMP (`prometheusremotewrite`)
+
+The config expects these environment variables in the collector container:
+
+```bash
+AWS_REGION=us-east-1
+AMP_ENDPOINT=https://aps-workspaces.us-east-1.amazonaws.com/workspaces/<workspace-id>/api/v1/remote_write
+CW_LOG_GROUP=/aws/ecs/auth-service/metrics
+CW_LOG_STREAM=otel
+CW_METRIC_NAMESPACE=AuthService
+```
+
+## 2) App container settings
+
+Set the app to export to the local sidecar:
+
+```bash
+OTEL_EXPORTER_OTLP_ENDPOINT=localhost:4317
+OTEL_EXPORTER_OTLP_PROTOCOL=grpc
+OTEL_EXPORTER_OTLP_INSECURE=true
+OTEL_SERVICE_NAME=auth-service
+```
+
+## 3) ECS task definition example
+
+Below is a condensed task definition snippet that runs the collector sidecar and
+injects the config from SSM Parameter Store. The collector writes the config to
+disk before starting.
+
+```json
+{
+  "family": "auth-service",
+  "networkMode": "awsvpc",
+  "requiresCompatibilities": ["EC2", "FARGATE"],
+  "cpu": "512",
+  "memory": "1024",
+  "containerDefinitions": [
+    {
+      "name": "auth-service",
+      "image": "<your-app-image>",
+      "portMappings": [{ "containerPort": 8080, "protocol": "tcp" }],
+      "environment": [
+        { "name": "OTEL_EXPORTER_OTLP_ENDPOINT", "value": "localhost:4317" },
+        { "name": "OTEL_EXPORTER_OTLP_PROTOCOL", "value": "grpc" },
+        { "name": "OTEL_EXPORTER_OTLP_INSECURE", "value": "true" },
+        { "name": "OTEL_SERVICE_NAME", "value": "auth-service" }
+      ],
+      "dependsOn": [{ "containerName": "adot-collector", "condition": "START" }]
+    },
+    {
+      "name": "adot-collector",
+      "image": "public.ecr.aws/aws-observability/aws-otel-collector:latest",
+      "essential": true,
+      "command": [
+        "/bin/sh",
+        "-c",
+        "echo \"$ADOT_COLLECTOR_CONFIG\" > /etc/otel-collector-config.yaml && /awscollector --config /etc/otel-collector-config.yaml"
+      ],
+      "secrets": [
+        {
+          "name": "ADOT_COLLECTOR_CONFIG",
+          "valueFrom": "arn:aws:ssm:us-east-1:123456789012:parameter/auth-service/adot-config"
+        }
+      ],
+      "environment": [
+        { "name": "AWS_REGION", "value": "us-east-1" },
+        { "name": "AMP_ENDPOINT", "value": "https://aps-workspaces.us-east-1.amazonaws.com/workspaces/<workspace-id>/api/v1/remote_write" },
+        { "name": "CW_LOG_GROUP", "value": "/aws/ecs/auth-service/metrics" },
+        { "name": "CW_LOG_STREAM", "value": "otel" },
+        { "name": "CW_METRIC_NAMESPACE", "value": "AuthService" }
+      ],
+      "logConfiguration": {
+        "logDriver": "awslogs",
+        "options": {
+          "awslogs-group": "/aws/ecs/auth-service",
+          "awslogs-region": "us-east-1",
+          "awslogs-stream-prefix": "adot"
+        }
+      }
+    }
+  ]
+}
+```
+
+## 4) IAM permissions
+
+Ensure the task role has permissions to export telemetry:
+
+- `xray:PutTraceSegments`, `xray:PutTelemetryRecords`
+- `logs:CreateLogGroup`, `logs:CreateLogStream`, `logs:PutLogEvents`
+- `aps:RemoteWrite`
+
+Also allow the task execution role to read the SSM parameter that stores
+`ADOT_COLLECTOR_CONFIG`.

--- a/telemetry/ADOT-LOCAL.md
+++ b/telemetry/ADOT-LOCAL.md
@@ -58,3 +58,9 @@ received spans/metrics because the config uses the `debug` exporter.
 
 Once you confirm local exports, swap the `debug` exporter in the collector
 config for AWS exporters (e.g., X-Ray, CloudWatch, AMP) and supply credentials.
+
+## ECS sidecar setup
+
+If you are running this service on ECS with a per-service ADOT sidecar,
+see [`telemetry/ADOT-ECS-SIDECAR.md`](ADOT-ECS-SIDECAR.md) for a task definition
+example and collector configuration that forwards to X-Ray, CloudWatch, and AMP.

--- a/telemetry/adot-collector-ecs.yaml
+++ b/telemetry/adot-collector-ecs.yaml
@@ -1,0 +1,43 @@
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:4317
+
+processors:
+  resourcedetection:
+    detectors: [ecs, env]
+    timeout: 2s
+    override: false
+  batch: {}
+
+exporters:
+  awsxray: {}
+  awsemf:
+    region: ${AWS_REGION}
+    namespace: ${CW_METRIC_NAMESPACE}
+    log_group_name: ${CW_LOG_GROUP}
+    log_stream_name: ${CW_LOG_STREAM}
+    resource_to_telemetry_conversion:
+      enabled: true
+  prometheusremotewrite:
+    endpoint: ${AMP_ENDPOINT}
+    auth:
+      authenticator: sigv4auth
+
+extensions:
+  sigv4auth:
+    region: ${AWS_REGION}
+    service: aps
+
+service:
+  extensions: [sigv4auth]
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [resourcedetection, batch]
+      exporters: [awsxray]
+    metrics:
+      receivers: [otlp]
+      processors: [resourcedetection, batch]
+      exporters: [awsemf, prometheusremotewrite]


### PR DESCRIPTION
### Motivation

- Provide a supported pattern for running a per-service ADOT (OpenTelemetry) collector as a sidecar on ECS so each task/pod runs its own collector and the app can export to `localhost:4317`.
- Make it easy to forward OTLP data from the local sidecar to AWS observability backends (X-Ray, CloudWatch, AMP) with example config and a task definition snippet.

### Description

- Added `telemetry/adot-collector-ecs.yaml` which defines an ADOT collector configuration receiving OTLP on `4317`, detecting ECS resources, and exporting traces to `awsxray` and metrics to `awsemf` and `prometheusremotewrite` using `sigv4auth` for AMP writes.
- Added `telemetry/ADOT-ECS-SIDECAR.md` with instructions for collector environment variables, app container OTLP environment settings, a condensed ECS task definition showing the sidecar container and how to inject the collector config, and required IAM permissions.
- Updated `telemetry/ADOT-LOCAL.md` to link to the new ECS sidecar guide and point users to the ECS-specific collector config.

### Testing

- No automated tests were run because this change is documentation and configuration only.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69748669a4dc832e8784d78c7d1c32e7)