### PR TITLE
Map branch prefixes to semver bumps; add `minor/**` CI trigger and fix Trivy input

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -50,10 +50,12 @@ jobs:
           merge_source=$(echo "$commit_message" | sed -n 's/.*from .*\/\([^ ]*\).*/\1/p')
 
           bump="patch"
-          if echo "$commit_message" | grep -Eiq 'breaking|BREAKING CHANGE' || echo "$merge_source" | grep -Eiq '^breaking/'; then
+          if echo "$commit_message" | grep -Eiq 'breaking|BREAKING CHANGE' || echo "$merge_source" | grep -Eiq '^(breaking|major)/'; then
             bump="major"
-          elif echo "$commit_message" | grep -Eiq 'feat' || echo "$merge_source" | grep -Eiq '^feat/'; then
+          elif echo "$commit_message" | grep -Eiq 'feat' || echo "$merge_source" | grep -Eiq '^(feat|minor)/'; then
             bump="minor"
+          elif echo "$merge_source" | grep -Eiq '^(fix|patch)/'; then
+            bump="patch"
           fi
 
           case "$bump" in

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,6 +9,7 @@ on:
       - main
       - feat/**
       - fix/**
+      - minor/**
       - breaking/**
 
 permissions:
@@ -82,7 +83,7 @@ jobs:
           scan-type: fs
           scan-ref: .
           severity: HIGH,CRITICAL
-          security-checks: vuln,secret,config
+          scanners: vuln,secret,config
           ignore-unfixed: true
           exit-code: "1"
           format: sarif

--- a/README.md
+++ b/README.md
@@ -8,3 +8,10 @@ Authentication service for the JB platform. This repository ships the Go service
 - Latest version: v1.0.0
 - Release date (UTC): 1970-01-01
 <!-- release-end -->
+
+## Versioning
+
+Version bumps are derived from branch prefixes when building releases:
+- `major/` or `breaking/` → major version bump.
+- `minor/` or `feat/` → minor version bump.
+- `patch/` or `fix/` → patch version bump.


### PR DESCRIPTION
### Motivation
- Ensure automatic semantic versioning uses branch-name conventions in addition to commit messages when building releases. 
- Make CI pushes follow repository branching practices by running checks for `minor/*` branches. 
- Eliminate a deprecated Trivy input to avoid warnings and ensure scans use the correct option.

### Description
- Update ` .github/workflows/build.yaml` to detect branch prefixes `major/`, `minor/`, and `patch/` (in addition to `breaking/`, `feat`, and `fix`) when computing the next semantic version and set the `bump` accordingly, including an explicit `^(fix|patch)/` check to force patch bumps. 
- Update ` .github/workflows/ci.yaml` to add `minor/**` to `push.branches` and replace the deprecated `security-checks` input with `scanners` for the Trivy repository scan. 
- Add a `Versioning` section to `README.md` documenting the mapping of branch prefixes to semver bumps: `major/` or `breaking/` → major, `minor/` or `feat/` → minor, and `patch/` or `fix/` → patch.

### Testing
- No automated tests were run because these are GitHub Actions workflow configuration and documentation changes only.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6974d80d5a20832e8147dca71bfd501a)